### PR TITLE
Patch of "printLog" in tuxedo-tomte

### DIFF
--- a/src/tuxedo-tomte
+++ b/src/tuxedo-tomte
@@ -4102,6 +4102,11 @@ sub printLog {
 	if (!defined($type)) {
 		$type = 'l1';
 	}
+	else {
+		if ($type =~ /^[lt]+$/i) {
+			$type = "${type}1";
+		}
+	}
 	my $level = $type;
 	$level =~ s/\D//g;
 	if ($level <= $logLevel) {


### PR DESCRIPTION
If printLog is called with l, L, t, T or a combination of them but without a loglevel in $type: Attach "1" to $type.

For example printLog is called with 'TL' only if "This OS is not supported". Before this patch this generates an error message.