### PR TITLE
Support of some Ubuntu forks

### DIFF
--- a/src/tuxedo-tomte
+++ b/src/tuxedo-tomte
@@ -877,11 +877,11 @@ sub readOSData {
 			$distributionVersion = $1;
 		}
 		elsif ( $_ =~ /^ID_LIKE=/ ) {
-			$_ =~ /ID_LIKE=\"(.*)\"/;
+			$_ =~ /ID_LIKE=(.*)/;
 			$distributionIdLike = $1;
 		}
 		elsif ( $_ =~ /^VERSION_CODENAME=/ ) {
-			$_ =~ /VERSION_CODENAME=\"(.*)\"/;
+			$_ =~ /VERSION_CODENAME=(.*)/;
 			$distributionVersionCodename = $1;
 		}
 	}
@@ -896,7 +896,7 @@ sub readOSData {
 sub workaroundUbuntuForks {
 	if ( $distributionIdLike =~ /^ubuntu$/ ) {
 		if ( $distributionVersionCodename =~ /^(bionic|focal)$/ ) {
-			printLog("Workaround Ubuntu forks: Change $distribution to Ubuntu and use sources of $distributionVersionCodename", 'TL0');
+			printLog("Workaround Ubuntu forks: Change '$distribution' to 'Ubuntu' and use sources of '$distributionVersionCodename'", 'TL0');
 			$distribution = 'Ubuntu';
 			
 			if ( $distributionVersionCodename =~ /^bionic$/ ) {

--- a/src/tuxedo-tomte
+++ b/src/tuxedo-tomte
@@ -47,6 +47,8 @@ my $shareDir = '/usr/share/tuxedo-tomte/';
 my $reposList = $shareDir.'repolist.txt';
 my $distribution;
 my $distributionVersion;
+my $distributionIdLike;
+my $distributionVersionCodename;
 my $FAI = 0;
 my $networkSearchDone = 0;
 my $triesFile = '/tmp/tomteTries';
@@ -870,9 +872,39 @@ sub readOSData {
 			$_ =~ /NAME=\"(.*)\"/;
 			$distribution = $1;
 		}
-		if ( $_ =~ /^VERSION_ID=/ ) {
+		elsif ( $_ =~ /^VERSION_ID=/ ) {
 			$_ =~ /VERSION_ID=\"(.*)\"/;
 			$distributionVersion = $1;
+		}
+		elsif ( $_ =~ /^ID_LIKE=/ ) {
+			$_ =~ /ID_LIKE=\"(.*)\"/;
+			$distributionIdLike = $1;
+		}
+		elsif ( $_ =~ /^VERSION_CODENAME=/ ) {
+			$_ =~ /VERSION_CODENAME=\"(.*)\"/;
+			$distributionVersionCodename = $1;
+		}
+	}
+}
+
+
+
+###############################################################################
+# correct $distribution and $distributionVersion if OS is an Ubuntu fork with
+# same sources
+
+sub workaroundUbuntuForks {
+	if ( $distributionIdLike =~ /^ubuntu$/ ) {
+		if ( $distributionVersionCodename =~ /^(bionic|focal)$/ ) {
+			printLog("Workaround Ubuntu forks: Change $distribution to Ubuntu and use sources of $distributionVersionCodename", 'TL0');
+			$distribution = 'Ubuntu';
+			
+			if ( $distributionVersionCodename =~ /^bionic$/ ) {
+				$distributionVersion = '18.04';
+			}
+			elsif ( $distributionVersionCodename =~ /^focal$/ ) {
+				$distributionVersion = '20.04';
+			}
 		}
 	}
 }
@@ -4102,10 +4134,8 @@ sub printLog {
 	if (!defined($type)) {
 		$type = 'l1';
 	}
-	else {
-		if ($type =~ /^[lt]+$/i) {
-			$type = "${type}1";
-		}
+	elsif ($type =~ /^[lt]+$/i) {
+		$type = "${type}1";
 	}
 	my $level = $type;
 	$level =~ s/\D//g;
@@ -5145,6 +5175,8 @@ if (!tuxedoDevice()) {
 }
 
 readOSData();
+
+workaroundUbuntuForks();
 
 if (!isOSSupported()) {
 	printLog('This OS is not supported', 'TL');


### PR DESCRIPTION
Support of some Ubuntu forks like Zorin OS:
1) Extended to global variables $distributionIdLike and $distributionVersionCodename
2) Extended readOSData to use ID_LIKE and VERSION_CODENAME of /etc/os-release
3) Extended to a new function workaroundUbuntuForks to make script working in Ubuntu forks with normally same sources like Zorin OS
(This version is more flexibel than check and correct $distribution and $distributionVersion)

Little correction of branch LittleIgnus-patch-printLog:
Use elsif instead else with following if in function printLog